### PR TITLE
fix(db): ajouter la table user_profiles manquante

### DIFF
--- a/APP/MY_budget/backend/init.sql
+++ b/APP/MY_budget/backend/init.sql
@@ -49,8 +49,21 @@ CREATE TABLE IF NOT EXISTS savings_goals (
   updated_at TIMESTAMP DEFAULT NOW()
 );
 
+CREATE TABLE IF NOT EXISTS user_profiles (
+  id SERIAL PRIMARY KEY,
+  user_id INT UNIQUE REFERENCES users(id) ON DELETE CASCADE,
+  profile_type VARCHAR(255),
+  revenus_mensuels VARCHAR(255),
+  situation_familiale VARCHAR(255),
+  objectifs_epargne TEXT[],
+  categories_prioritaires TEXT[],
+  created_at TIMESTAMP DEFAULT NOW(),
+  updated_at TIMESTAMP DEFAULT NOW()
+);
+
 CREATE INDEX IF NOT EXISTS idx_transactions_user_id ON transactions(user_id);
 CREATE INDEX IF NOT EXISTS idx_transactions_created_at ON transactions(created_at);
 CREATE INDEX IF NOT EXISTS idx_budgets_user_id ON budgets(user_id);
 CREATE INDEX IF NOT EXISTS idx_savings_goals_user_id ON savings_goals(user_id);
+CREATE INDEX IF NOT EXISTS idx_user_profiles_user_id ON user_profiles(user_id);
 


### PR DESCRIPTION
## Problème

La table `user_profiles` n'était pas définie dans `init.sql`, ce qui causait une erreur 500 sur tous les endpoints `/api/profile` en production.

## Solution

Ajout de la table `user_profiles` dans le schéma PostgreSQL avec :
- Clé étrangère vers `users(id)` avec `ON DELETE CASCADE`
- Contrainte `UNIQUE` sur `user_id` (un profil par utilisateur)
- Colonnes : `profile_type`, `revenus_mensuels`, `situation_familiale`, `objectifs_epargne`, `categories_prioritaires`
- Index sur `user_id` pour les performances

## Test

Table créée manuellement sur l'instance AWS et vérifiée fonctionnelle.
